### PR TITLE
Accept by Tab key

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,10 +98,11 @@ impl<'a> Widget for AutoCompleteTextEdit<'a> {
             max_suggestions,
         );
 
-        let enter_pressed = ui.input_mut(|input| input.key_pressed(Key::Enter));
+        let accepted_by_keyboard = ui.input_mut(|input| input.key_pressed(Key::Enter)) ||
+            ui.input_mut(|input| input.key_pressed(Key::Tab));
         if let (Some(index), true) = (
             state.selected_index,
-            enter_pressed && ui.memory(|mem| mem.is_popup_open(id)),
+            ui.memory(|mem| mem.is_popup_open(id)) && accepted_by_keyboard,
         ) {
             text_field.replace(match_results[index].0)
         }


### PR DESCRIPTION
Thanks for this wonderful widget. I've been using it in my project for a week now. However, I find myself habitually tapping tab after selecting a completion and the focus moves out, which is annoying.

I believe Tab key for completion is sort of a convention now (bash, emacs, vscode, etc). So I reckon we may support that. How do you think?

(<del>I created this PR as draft because I haven't time to verify if this will collide with egui's tab-triggered focus move. I will convert it to a PR after I confirmed that it indeed works.</del> I have confirmed that it works as intended)